### PR TITLE
Changed to explicitly throw NullPointerException.

### DIFF
--- a/src/main/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/experimental/CoroutineCallAdapterFactory.kt
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/experimental/CoroutineCallAdapterFactory.kt
@@ -99,7 +99,13 @@ class CoroutineCallAdapterFactory private constructor() : CallAdapter.Factory() 
 
         override fun onResponse(call: Call<T>, response: Response<T>) {
           if (response.isSuccessful) {
-            deferred.complete(response.body()!!)
+            val body = response.body()
+            if (body == null) {
+              deferred.completeExceptionally(NullPointerException("Response body is null"))
+              return
+            }
+
+            deferred.complete(body)
           } else {
             deferred.completeExceptionally(HttpException(response))
           }


### PR DESCRIPTION
Changed to throw NullPointerException via `deferred.completeExceptionally` if `response.body` is null.

Previously it was forcibly converted by the [!! operator](https://kotlinlang.org/docs/reference/null-safety.html#the--operator), so the user was unable to catch NullPointerException.

By throwing NullPointerException, the user side can handle error handling.