### PR TITLE
Bump Kotlin to 1.3-M1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,10 @@
 buildscript {
   repositories {
     mavenCentral()
+    maven { url "http://dl.bintray.com/kotlin/kotlin-eap"}
   }
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.10'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3-M1'
   }
 }
 
@@ -16,12 +17,13 @@ sourceCompatibility = JavaVersion.VERSION_1_6
 
 repositories {
   mavenCentral()
+  maven { url "http://dl.bintray.com/kotlin/kotlin-eap"}
 }
 
 dependencies {
   api 'com.squareup.retrofit2:retrofit:2.3.0'
   api 'org.jetbrains.kotlin:kotlin-stdlib:1.2.10'
-  api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.20'
+  api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.24.0-eap13'
 
   testImplementation 'junit:junit:4.12'
   testImplementation 'com.squareup.okhttp3:mockwebserver:3.9.1'

--- a/src/main/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CoroutineCallAdapterFactory.kt
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CoroutineCallAdapterFactory.kt
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jakewharton.retrofit2.adapter.kotlin.coroutines.experimental
+package com.jakewharton.retrofit2.adapter.kotlin.coroutines
 
-import kotlinx.coroutines.experimental.CompletableDeferred
-import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.Deferred
 import retrofit2.Call
 import retrofit2.CallAdapter
 import retrofit2.Callback

--- a/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CancelTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CancelTest.kt
@@ -1,9 +1,9 @@
 @file:Suppress("UNCHECKED_CAST")
 
-package com.jakewharton.retrofit2.adapter.kotlin.coroutines.experimental
+package com.jakewharton.retrofit2.adapter.kotlin.coroutines
 
 import com.google.common.reflect.TypeToken
-import kotlinx.coroutines.experimental.Deferred
+import kotlinx.coroutines.Deferred
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test

--- a/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CompletableCall.kt
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CompletableCall.kt
@@ -1,4 +1,4 @@
-package com.jakewharton.retrofit2.adapter.kotlin.coroutines.experimental
+package com.jakewharton.retrofit2.adapter.kotlin.coroutines
 
 import okhttp3.Request
 import retrofit2.Call

--- a/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CoroutineCallAdapterFactoryTest.java
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CoroutineCallAdapterFactoryTest.java
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jakewharton.retrofit2.adapter.kotlin.coroutines.experimental;
+package com.jakewharton.retrofit2.adapter.kotlin.coroutines;
 
 import com.google.common.reflect.TypeToken;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.List;
-import kotlinx.coroutines.experimental.Deferred;
+import kotlinx.coroutines.Deferred;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.Before;
 import org.junit.Rule;

--- a/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/DeferredTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/DeferredTest.kt
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jakewharton.retrofit2.adapter.kotlin.coroutines.experimental
+package com.jakewharton.retrofit2.adapter.kotlin.coroutines
 
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.experimental.Deferred
-import kotlinx.coroutines.experimental.runBlocking
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.runBlocking
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.SocketPolicy.DISCONNECT_AFTER_REQUEST

--- a/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/StringConverterFactory.java
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/StringConverterFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.jakewharton.retrofit2.adapter.kotlin.coroutines.experimental;
+package com.jakewharton.retrofit2.adapter.kotlin.coroutines;
 
 import java.io.IOException;
 import java.lang.annotation.Annotation;


### PR DESCRIPTION
I would like to try Kotlin 1.3, but since this library is incompatible, I sent this PR.