### PR TITLE
Proper cause for Exceptions Deferred is resumed with

### DIFF
--- a/src/main/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CoroutineCallAdapterFactory.kt
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CoroutineCallAdapterFactory.kt
@@ -17,7 +17,12 @@ package com.jakewharton.retrofit2.adapter.kotlin.coroutines
 
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Deferred
-import retrofit2.*
+import retrofit2.Call
+import retrofit2.CallAdapter
+import retrofit2.Callback
+import retrofit2.HttpException
+import retrofit2.Response
+import retrofit2.Retrofit
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 

--- a/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/DeferredTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/DeferredTest.kt
@@ -33,21 +33,17 @@ import retrofit2.http.GET
 import java.io.IOException
 
 class DeferredTest {
-  @get:Rule
-  val server = MockWebServer()
+  @get:Rule val server = MockWebServer()
 
   private lateinit var service: Service
 
   interface Service {
-    @GET("/")
-    fun body(): Deferred<String>
+    @GET("/") fun body(): Deferred<String>
 
-    @GET("/")
-    fun response(): Deferred<Response<String>>
+    @GET("/") fun response(): Deferred<Response<String>>
   }
 
-  @Before
-  fun setUp() {
+  @Before fun setUp() {
     val retrofit = Retrofit.Builder()
         .baseUrl(server.url("/"))
         .addConverterFactory(StringConverterFactory())
@@ -56,16 +52,14 @@ class DeferredTest {
     service = retrofit.create(Service::class.java)
   }
 
-  @Test
-  fun bodySuccess200() = runBlocking {
+  @Test fun bodySuccess200() = runBlocking {
     server.enqueue(MockResponse().setBody("Hi"))
 
     val deferred = service.body()
     assertThat(deferred.await()).isEqualTo("Hi")
   }
 
-  @Test
-  fun bodySuccess404() = runBlocking {
+  @Test fun bodySuccess404() = runBlocking {
     server.enqueue(MockResponse().setResponseCode(404))
 
     val currentFrame = Exception().stackTrace[0]
@@ -81,8 +75,7 @@ class DeferredTest {
     }
   }
 
-  @Test
-  fun bodyFailure() = runBlocking {
+  @Test fun bodyFailure() = runBlocking {
     server.enqueue(MockResponse().setSocketPolicy(DISCONNECT_AFTER_REQUEST))
 
     val currentFrame = Exception().stackTrace[0]
@@ -96,8 +89,7 @@ class DeferredTest {
     }
   }
 
-  @Test
-  fun responseSuccess200() = runBlocking {
+  @Test fun responseSuccess200() = runBlocking {
     server.enqueue(MockResponse().setBody("Hi"))
 
     val deferred = service.response()
@@ -106,8 +98,7 @@ class DeferredTest {
     assertThat(response.body()).isEqualTo("Hi")
   }
 
-  @Test
-  fun responseSuccess404() = runBlocking {
+  @Test fun responseSuccess404() = runBlocking {
     server.enqueue(MockResponse().setResponseCode(404).setBody("Hi"))
 
     val deferred = service.response()

--- a/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/DeferredTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/DeferredTest.kt
@@ -39,7 +39,6 @@ class DeferredTest {
 
   interface Service {
     @GET("/") fun body(): Deferred<String>
-
     @GET("/") fun response(): Deferred<Response<String>>
   }
 

--- a/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/DeferredTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/DeferredTest.kt
@@ -106,8 +106,7 @@ class DeferredTest {
     assertThat(response.errorBody()!!.string()).isEqualTo("Hi")
   }
 
-  @Test
-  fun responseFailure() = runBlocking {
+  @Test fun responseFailure() = runBlocking {
     server.enqueue(MockResponse().setSocketPolicy(DISCONNECT_AFTER_REQUEST))
 
     val currentFrame = Exception().stackTrace[0]


### PR DESCRIPTION
I really like this library, but it has caused me some headaches related to network errors. Continuations are resumed with the Exception thrown by OkHttp, but unfortunately that Exception contains no indication about where the network request was started. This is because OkHttp of course uses a thread pool and thus the stack trace only includes internal OkHttp code.

With this PR, the stack during the call to `await` is recorded. In case of a failure, the `Exception` cause chain is traversed and another Exception that contains the recorded stack trace is appended. This way users of this library will be able to easily figure out which `await` call in particular has caused an `Exception` without manually wrapping every call to `await` in a try-catch block that wraps it in another locally-created `Exception`.