### PR TITLE
Add support for nullable bodies

### DIFF
--- a/src/main/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CoroutineCallAdapterFactory.kt
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CoroutineCallAdapterFactory.kt
@@ -150,4 +150,4 @@ class CoroutineCallAdapterFactory private constructor() : CallAdapter.Factory() 
  * Denotes that the body of an HTTP response may be null.
  * @see CoroutineCallAdapterFactory
  */
-annotation class NullableBody
+@Target(AnnotationTarget.FUNCTION) annotation class NullableBody

--- a/src/main/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CoroutineCallAdapterFactory.kt
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CoroutineCallAdapterFactory.kt
@@ -41,7 +41,7 @@ import java.lang.reflect.Type
  *
  * * Direct body (e.g., `Deferred<User>`) returns the deserialized body for 2XX responses, throws
  * [HttpException] errors for non-2XX responses, and throws [IOException][java.io.IOException] for
- * network errors.
+ * network errors. In case of a nullable body, you need to add the [NullableBody] annotation to the method.
  * * Response wrapped body (e.g., `Deferred<Response<User>>`) returns a [Response] object for all
  * HTTP responses and throws [IOException][java.io.IOException] for network errors
  */
@@ -73,18 +73,19 @@ class CoroutineCallAdapterFactory private constructor() : CallAdapter.Factory() 
       }
       ResponseCallAdapter<Any>(getParameterUpperBound(0, responseType))
     } else {
-      BodyCallAdapter<Any>(responseType)
+      BodyCallAdapter<Any>(responseType, nullableBody = annotations.any { it is NullableBody })
     }
   }
 
   private class BodyCallAdapter<T>(
-      private val responseType: Type
-  ) : CallAdapter<T, Deferred<T>> {
+      private val responseType: Type,
+      private val nullableBody: Boolean
+  ) : CallAdapter<T, Deferred<T?>> {
 
     override fun responseType() = responseType
 
-    override fun adapt(call: Call<T>): Deferred<T> {
-      val deferred = CompletableDeferred<T>()
+    override fun adapt(call: Call<T>): Deferred<T?> {
+      val deferred = CompletableDeferred<T?>()
 
       deferred.invokeOnCompletion {
         if (deferred.isCancelled) {
@@ -99,7 +100,12 @@ class CoroutineCallAdapterFactory private constructor() : CallAdapter.Factory() 
 
         override fun onResponse(call: Call<T>, response: Response<T>) {
           if (response.isSuccessful) {
-            deferred.complete(response.body()!!)
+            val body = if (nullableBody) {
+              response.body()
+            } else {
+              response.body() ?: throw NullPointerException("Body is null, but method not annotated with NullableBody")
+            }
+            deferred.complete(body)
           } else {
             deferred.completeExceptionally(HttpException(response))
           }
@@ -139,3 +145,9 @@ class CoroutineCallAdapterFactory private constructor() : CallAdapter.Factory() 
     }
   }
 }
+
+/**
+ * Denotes that the body of an HTTP response may be null.
+ * @see CoroutineCallAdapterFactory
+ */
+annotation class NullableBody

--- a/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/DeferredTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/DeferredTest.kt
@@ -38,7 +38,8 @@ class DeferredTest {
 
   interface Service {
     @GET("/") fun body(): Deferred<String>
-    @GET("/") fun response(): Deferred<Response<String>>
+    @GET("/") @NullableBody fun nullableBody(): Deferred<String?>
+    @GET("/") fun response(): Deferred<Response<String?>>
   }
 
   @Before fun setUp() {
@@ -55,6 +56,13 @@ class DeferredTest {
 
     val deferred = service.body()
     assertThat(deferred.await()).isEqualTo("Hi")
+  }
+
+  @Test fun bodySuccess204() = runBlocking {
+    server.enqueue(MockResponse().setResponseCode(204))
+
+    val deferred = service.nullableBody()
+    assertThat(deferred.await()).isNull()
   }
 
   @Test fun bodySuccess404() = runBlocking {

--- a/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/DeferredTest.kt
+++ b/src/test/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/DeferredTest.kt
@@ -39,7 +39,7 @@ class DeferredTest {
   interface Service {
     @GET("/") fun body(): Deferred<String>
     @GET("/") @NullableBody fun nullableBody(): Deferred<String?>
-    @GET("/") fun response(): Deferred<Response<String?>>
+    @GET("/") fun response(): Deferred<Response<String>>
   }
 
   @Before fun setUp() {


### PR DESCRIPTION
This PR aims to resolve issue #5. Since it currently seems infeasible to extract nullability information from the bytecode directly, an annotation `NullableBody` is introduced that methods returning nullable bodies are annotated with. In case this annotation is found, the `!!` null check is omitted. 