### PR TITLE
Fix void response type NPE crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     maven { url 'http://dl.bintray.com/kotlin/kotlin-eap' }
   }
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.0-rc-57'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.0'
   }
 }
 
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
   api 'com.squareup.retrofit2:retrofit:2.4.0'
-  api 'org.jetbrains.kotlin:kotlin-stdlib:1.3.0-rc-57'
+  api 'org.jetbrains.kotlin:kotlin-stdlib:1.3.0'
   api 'org.jetbrains.kotlinx:kotlinx-coroutines-core:0.26.1-eap13'
 
   testImplementation 'junit:junit:4.12'

--- a/src/main/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CoroutineCallAdapterFactory.kt
+++ b/src/main/java/com/jakewharton/retrofit2/adapter/kotlin/coroutines/CoroutineCallAdapterFactory.kt
@@ -79,12 +79,12 @@ class CoroutineCallAdapterFactory private constructor() : CallAdapter.Factory() 
 
   private class BodyCallAdapter<T>(
       private val responseType: Type
-  ) : CallAdapter<T, Deferred<T>> {
+  ) : CallAdapter<T, Deferred<T?>> {
 
     override fun responseType() = responseType
 
-    override fun adapt(call: Call<T>): Deferred<T> {
-      val deferred = CompletableDeferred<T>()
+    override fun adapt(call: Call<T>): Deferred<T?> {
+      val deferred = CompletableDeferred<T?>()
 
       deferred.invokeOnCompletion {
         if (deferred.isCancelled) {
@@ -99,7 +99,7 @@ class CoroutineCallAdapterFactory private constructor() : CallAdapter.Factory() 
 
         override fun onResponse(call: Call<T>, response: Response<T>) {
           if (response.isSuccessful) {
-            deferred.complete(response.body()!!)
+            deferred.complete(response.body())
           } else {
             deferred.completeExceptionally(HttpException(response))
           }


### PR DESCRIPTION
The call adapter crashes with an KotlinNullPointerException when a Void response type is used

```
kotlin.KotlinNullPointerException
	at com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory$BodyCallAdapter$adapt$2.onResponse(CoroutineCallAdapterFactory.kt:102)
	at retrofit2.OkHttpCall$1.onResponse(OkHttpCall.java:123)
	at okhttp3.RealCall$AsyncCall.execute(RealCall.java:153)
	at okhttp3.internal.NamedRunnable.run(NamedRunnable.java:32)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```