### PR TITLE
Update README.md to use CoroutineCallAdapterFactory.create()

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add `CoroutineCallAdapterFactory` as a `Call` adapter when building your `Retrof
 ```kotlin
 val retrofit = Retrofit.Builder()
     .baseUrl("https://example.com/")
-    .addCallAdapterFactory(CoroutineCallAdapterFactory())
+    .addCallAdapterFactory(CoroutineCallAdapterFactory.create())
     .build()
 ```
 


### PR DESCRIPTION
Spent like 2 minutes on this, but I think its correct.